### PR TITLE
Renamed 'Add' to 'Set'

### DIFF
--- a/concurrent_map.go
+++ b/concurrent_map.go
@@ -23,8 +23,8 @@ func NewConcurrentMap() *ConcurrentMap {
 	return New()
 }
 
-// Adds an element to the map.
-func (m *ConcurrentMap) Add(key string, value interface{}) {
+// Adds or replaces an element in the map.
+func (m *ConcurrentMap) Set(key string, value interface{}) {
 	m.Lock()
 	defer m.Unlock()
 	m.m[key] = value


### PR DESCRIPTION
Although I updated the comment and changed the method name as well, at the very least the comment should state what happens when the key already exists in the map (even if it becomes obvious when reading the source).
