### PR TITLE
Divided map into shards

### DIFF
--- a/concurrent_map.go
+++ b/concurrent_map.go
@@ -1,76 +1,151 @@
 package cmap
 
 import (
+	"crypto/sha1"
 	"encoding/json"
+	"fmt"
 	"sync"
 )
 
 // TODO: Add Keys function which returns an array of keys for the map.
 
 // A "thread" safe map of type string:Anything.
+// To avoid lock bottlenecks this map is dived to several (256) map shards.
 type ConcurrentMap struct {
-	m            map[string]interface{} // map with string key and any type of object as value.
-	sync.RWMutex                        // Read Write mutex, guards access to internal map.
+	shards       map[string]*ConcurrentMapShared
+	sync.RWMutex // Read Write mutex, guards access to internal map.
 }
 
-// Creates a new concurent map.
+// A "thread" safe string to anything map.
+type ConcurrentMapShared struct {
+	items        map[string]interface{}
+	sync.RWMutex // Read Write mutex, guards access to internal map.
+}
+
+// Creates a new concurrent map.
 func New() *ConcurrentMap {
-	return &ConcurrentMap{m: make(map[string]interface{})}
+	return &ConcurrentMap{shards: make(map[string]*ConcurrentMapShared, 256)}
 }
 
-// Alias for New()
-func NewConcurrentMap() *ConcurrentMap {
-	return New()
-}
+// Returns shard under given key, incase shared is missing and create is true
+// the function will create the missing shard.
+func (m *ConcurrentMap) GetShard(key string, create bool) (shard *ConcurrentMapShared, ok bool) {
 
-// Adds an element to the map.
-func (m *ConcurrentMap) Add(key string, value interface{}) {
+	// Hash key.
+	hasher := sha1.New()
+	hasher.Write([]byte(key))
+
+	// Use last two digits of hashed key as our shard key.
+	shardKey := fmt.Sprintf("%x", hasher.Sum(nil))[0:2]
+
+	// Try to get shard.
+	m.RLock()
+	shard, ok = m.shards[shardKey]
+	m.RUnlock()
+
+	// Did we got a shard? Are we asked to create a missing shard?
+	if ok || !create {
+		return
+	}
+
+	// Recheck, write lock!
 	m.Lock()
 	defer m.Unlock()
-	m.m[key] = value
+	shard, ok = m.shards[shardKey]
+	if ok {
+		return
+	}
+
+	// Create shard.
+	shard = &ConcurrentMapShared{items: make(map[string]interface{}, 2048)}
+	m.shards[shardKey] = shard
+	ok = true
+	return
+}
+
+// Sets the given value under the specified key.
+func (m *ConcurrentMap) Set(key string, value interface{}) {
+
+	// Get map shard.
+	shard, _ := m.GetShard(key, true)
+	shard.Lock()
+	defer shard.Unlock()
+	shard.items[key] = value
+}
+
+// Retrieves an element from map under given key.
+func (m *ConcurrentMap) Get(key string) (interface{}, bool) {
+
+	// Get shard, don't create if missing.
+	shard, ok := m.GetShard(key, false)
+	if ok == false {
+		return nil, false
+	}
+
+	shard.RLock()
+	defer shard.RUnlock()
+
+	// Get item from shard.
+	val, ok := shard.items[key]
+	return val, ok
 }
 
 // Returns the number of elements within the map.
 func (m *ConcurrentMap) Count() int {
-	m.RLock()
-	defer m.RUnlock()
-	return len(m.m)
-}
+	count := 0
 
-// Retrives an element from map under given key.
-func (m *ConcurrentMap) Get(key string) (interface{}, bool) {
 	m.RLock()
 	defer m.RUnlock()
 
-	val, err := m.m[key]
-	return val, err
+	// Count number of items within each shard.
+	for _, val := range m.shards {
+		val.RLock()
+		count += len(val.items)
+		val.RUnlock()
+	}
+
+	return count
 }
 
 // Looks up an item under specified key
 func (m *ConcurrentMap) Has(key string) bool {
-	m.RLock()
-	defer m.RUnlock()
-	_, ok := m.m[key]
+	// Get shard, don't create if missing.
+	shard, ok := m.GetShard(key, false)
+	if ok == false {
+		return false
+	}
+
+	shard.RLock()
+	defer shard.RUnlock()
+
+	// See if element is within shard.
+	_, ok = shard.items[key]
 	return ok
 }
 
 // Removes an element from the map.
 func (m *ConcurrentMap) Remove(key string) {
-	m.Lock()
-	defer m.Unlock()
-	delete(m.m, key)
+	// Try to get shard.
+	shard, ok := m.GetShard(key, false)
+	if ok == false {
+		return
+	}
+
+	shard.Lock()
+	defer shard.Unlock()
+	delete(shard.items, key)
 }
 
 // Clears map by constructing a new one.
 func (m *ConcurrentMap) Clear() {
 	m.Lock()
 	defer m.Unlock()
-	m.m = make(map[string]interface{})
+	m.shards = make(map[string]*ConcurrentMapShared, 256)
 }
 
 // Checks if map is empty.
 func (m *ConcurrentMap) IsEmpty() bool {
-	return len(m.m) == 0
+	return m.Count() == 0
 }
 
 // Used by the Iter & IterBuffered functions to wrap two variables together over a channel,
@@ -85,8 +160,14 @@ func (m *ConcurrentMap) Iter() <-chan Tuple {
 	go func() {
 		m.RLock()
 		defer m.RUnlock()
-		for key, val := range m.m {
-			ch <- Tuple{key, val}
+		// Foreach shard.
+		for _, shard := range m.shards {
+			// Foreach key, value pair.
+			shard.RLock()
+			for key, val := range shard.items {
+				ch <- Tuple{key, val}
+			}
+			shard.RUnlock()
 		}
 		close(ch)
 	}()
@@ -99,16 +180,30 @@ func (m *ConcurrentMap) IterBuffered() <-chan Tuple {
 	go func() {
 		m.RLock()
 		defer m.RUnlock()
-		for key, val := range m.m {
-			ch <- Tuple{key, val}
+		// Foreach shard.
+		for _, shard := range m.shards {
+			// Foreach key, value pair.
+			shard.RLock()
+			for key, val := range shard.items {
+				ch <- Tuple{key, val}
+			}
+			shard.RUnlock()
 		}
 		close(ch)
 	}()
 	return ch
 }
 
+// Reviles ConcurrentMap "private" variables to json marshal.
 func (m ConcurrentMap) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
+		M map[string]*ConcurrentMapShared
+	}{M: m.shards})
+}
+
+// Reviles ConcurrentMapShared "private" variables to json marshal.
+func (m ConcurrentMapShared) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
 		M map[string]interface{}
-	}{M: m.m})
+	}{M: m.items})
 }

--- a/concurrent_map_test.go
+++ b/concurrent_map_test.go
@@ -27,8 +27,8 @@ func TestInsert(t *testing.T) {
 	elephant := Animal{"elephant"}
 	monkey := Animal{"monkey"}
 
-	m.Add("elephant", elephant)
-	m.Add("monkey", monkey)
+	m.Set("elephant", elephant)
+	m.Set("monkey", monkey)
 
 	if m.Count() != 2 {
 		t.Error("map should contain exactly two elements.")
@@ -50,7 +50,7 @@ func TestGet(t *testing.T) {
 	}
 
 	elephant := Animal{"elephant"}
-	m.Add("elephant", elephant)
+	m.Set("elephant", elephant)
 
 	// Retrieve inserted element.
 
@@ -79,7 +79,7 @@ func TestHas(t *testing.T) {
 	}
 
 	elephant := Animal{"elephant"}
-	m.Add("elephant", elephant)
+	m.Set("elephant", elephant)
 
 	if m.Has("elephant") == false {
 		t.Error("element exists, expecting Has to return True.")
@@ -90,7 +90,7 @@ func TestRemove(t *testing.T) {
 	m := New()
 
 	monkey := Animal{"monkey"}
-	m.Add("monkey", monkey)
+	m.Set("monkey", monkey)
 
 	m.Remove("monkey")
 
@@ -115,7 +115,7 @@ func TestRemove(t *testing.T) {
 func TestCount(t *testing.T) {
 	m := New()
 	for i := 0; i < 100; i++ {
-		m.Add(strconv.Itoa(i), Animal{strconv.Itoa(i)})
+		m.Set(strconv.Itoa(i), Animal{strconv.Itoa(i)})
 	}
 
 	if m.Count() != 100 {
@@ -133,7 +133,7 @@ func TestClear(t *testing.T) {
 
 	monkey := Animal{"monkey"}
 
-	m.Add("monkey", monkey)
+	m.Set("monkey", monkey)
 
 	m.Clear()
 	if m.Count() != 0 {
@@ -152,7 +152,7 @@ func TestIsEmpty(t *testing.T) {
 		t.Error("new map should be empty")
 	}
 
-	m.Add("elephant", Animal{"elephant"})
+	m.Set("elephant", Animal{"elephant"})
 
 	if m.IsEmpty() != false {
 		t.Error("map shouldn't be empty.")
@@ -164,7 +164,7 @@ func TestIterator(t *testing.T) {
 
 	// Insert 100 elements.
 	for i := 0; i < 100; i++ {
-		m.Add(strconv.Itoa(i), Animal{strconv.Itoa(i)})
+		m.Set(strconv.Itoa(i), Animal{strconv.Itoa(i)})
 	}
 
 	counter := 0
@@ -188,7 +188,7 @@ func TestBufferedIterator(t *testing.T) {
 
 	// Insert 100 elements.
 	for i := 0; i < 100; i++ {
-		m.Add(strconv.Itoa(i), Animal{strconv.Itoa(i)})
+		m.Set(strconv.Itoa(i), Animal{strconv.Itoa(i)})
 	}
 
 	counter := 0
@@ -217,7 +217,7 @@ func TestConcurrent(t *testing.T) {
 	go func() {
 		for i := 0; i < iterations/2; i++ {
 			// Add item to map.
-			m.Add(strconv.Itoa(i), i)
+			m.Set(strconv.Itoa(i), i)
 
 			// Retrieve item from map.
 			val, _ := m.Get(strconv.Itoa(i))
@@ -230,7 +230,7 @@ func TestConcurrent(t *testing.T) {
 	go func() {
 		for i := iterations / 2; i < iterations; i++ {
 			// Add item to map.
-			m.Add(strconv.Itoa(i), i)
+			m.Set(strconv.Itoa(i), i)
 
 			// Retrieve item from map.
 			val, _ := m.Get(strconv.Itoa(i))
@@ -267,10 +267,10 @@ func TestConcurrent(t *testing.T) {
 }
 
 func TestJsonMarshal(t *testing.T) {
-	expected := "{\"M\":{\"a\":1,\"b\":2}}"
+	expected := "{\"M\":{\"86\":{\"M\":{\"a\":1}},\"e9\":{\"M\":{\"b\":2}}}}"
 	m := New()
-	m.Add("a", 1)
-	m.Add("b", 2)
+	m.Set("a", 1)
+	m.Set("b", 2)
 	j, err := json.Marshal(m)
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
To get better performance and to avoid concurrency bottlenecks I’ve
sharded the map into 256 maps, each responsible for storing a portion
of the over all data, each with its own locking mech’.
