### PR TITLE
All methods to be pointer receivers

### DIFF
--- a/concurrent_map.go
+++ b/concurrent_map.go
@@ -27,12 +27,12 @@ func New() ConcurrentMap {
 }
 
 // Returns shard under given key
-func (m ConcurrentMap) GetShard(key string) *ConcurrentMapShared {
+func (m *ConcurrentMap) GetShard(key string) *ConcurrentMapShared {
 	sum := fnv32([]byte(key))
-	return m[uint(sum)%uint(SHARD_COUNT)]
+	return (*m)[uint(sum)%uint(SHARD_COUNT)]
 }
 
-func (m ConcurrentMap) MSet(data map[string]interface{}) {
+func (m *ConcurrentMap) MSet(data map[string]interface{}) {
 	for key, value := range data {
 		shard := m.GetShard(key)
 		shard.Lock()
@@ -81,7 +81,7 @@ func (m *ConcurrentMap) SetIfAbsent(key string, value interface{}) bool {
 }
 
 // Retrieves an element from map under given key.
-func (m ConcurrentMap) Get(key string) (interface{}, bool) {
+func (m *ConcurrentMap) Get(key string) (interface{}, bool) {
 	// Get shard
 	shard := m.GetShard(key)
 	shard.RLock()
@@ -92,10 +92,10 @@ func (m ConcurrentMap) Get(key string) (interface{}, bool) {
 }
 
 // Returns the number of elements within the map.
-func (m ConcurrentMap) Count() int {
+func (m *ConcurrentMap) Count() int {
 	count := 0
 	for i := 0; i < SHARD_COUNT; i++ {
-		shard := m[i]
+		shard := (*m)[i]
 		shard.RLock()
 		count += len(shard.items)
 		shard.RUnlock()
@@ -137,13 +137,13 @@ type Tuple struct {
 // Returns an iterator which could be used in a for range loop.
 //
 // Deprecated: using IterBuffered() will get a better performence
-func (m ConcurrentMap) Iter() <-chan Tuple {
+func (m *ConcurrentMap) Iter() <-chan Tuple {
 	ch := make(chan Tuple)
 	go func() {
 		wg := sync.WaitGroup{}
 		wg.Add(SHARD_COUNT)
 		// Foreach shard.
-		for _, shard := range m {
+		for _, shard := range (*m) {
 			go func(shard *ConcurrentMapShared) {
 				// Foreach key, value pair.
 				shard.RLock()
@@ -161,13 +161,13 @@ func (m ConcurrentMap) Iter() <-chan Tuple {
 }
 
 // Returns a buffered iterator which could be used in a for range loop.
-func (m ConcurrentMap) IterBuffered() <-chan Tuple {
+func (m *ConcurrentMap) IterBuffered() <-chan Tuple {
 	ch := make(chan Tuple, m.Count())
 	go func() {
 		wg := sync.WaitGroup{}
 		wg.Add(SHARD_COUNT)
 		// Foreach shard.
-		for _, shard := range m {
+		for _, shard := range (*m) {
 			go func(shard *ConcurrentMapShared) {
 				// Foreach key, value pair.
 				shard.RLock()
@@ -185,7 +185,7 @@ func (m ConcurrentMap) IterBuffered() <-chan Tuple {
 }
 
 // Returns all items as map[string]interface{}
-func (m ConcurrentMap) Items() map[string]interface{} {
+func (m *ConcurrentMap) Items() map[string]interface{} {
 	tmp := make(map[string]interface{})
 
 	// Insert items to temporary map.
@@ -197,14 +197,14 @@ func (m ConcurrentMap) Items() map[string]interface{} {
 }
 
 // Return all keys as []string
-func (m ConcurrentMap) Keys() []string {
+func (m *ConcurrentMap) Keys() []string {
 	count := m.Count()
 	ch := make(chan string, count)
 	go func() {
 		// Foreach shard.
 		wg := sync.WaitGroup{}
 		wg.Add(SHARD_COUNT)
-		for _, shard := range m {
+		for _, shard := range (*m) {
 			go func(shard *ConcurrentMapShared) {
 				// Foreach key, value pair.
 				shard.RLock()


### PR DESCRIPTION
Before:

```
BenchmarkItems-4                                 200       8286514 ns/op
BenchmarkMarshalJson-4                            50      25730621 ns/op
BenchmarkStrconv-4                          20000000           125 ns/op
BenchmarkSingleInsertAbsent-4                1000000          1600 ns/op
BenchmarkSingleInsertPresent-4               5000000           259 ns/op
BenchmarkMultiInsertDifferent_1_Shard-4       500000          4885 ns/op
BenchmarkMultiInsertDifferent_16_Shard-4      500000          4669 ns/op
BenchmarkMultiInsertDifferent_32_Shard-4      500000          4608 ns/op
BenchmarkMultiInsertDifferent_256_Shard-4     300000          5480 ns/op
BenchmarkMultiInsertSame-4                    500000          2738 ns/op
BenchmarkMultiGetSame-4                      1000000          1032 ns/op
BenchmarkMultiGetSetDifferent_1_Shard-4       300000          5963 ns/op
BenchmarkMultiGetSetDifferent_16_Shard-4      300000          5792 ns/op
BenchmarkMultiGetSetDifferent_32_Shard-4      300000          5737 ns/op
BenchmarkMultiGetSetDifferent_256_Shard-4     300000          5504 ns/op
BenchmarkMultiGetSetBlock_1_Shard-4           300000          4404 ns/op
BenchmarkMultiGetSetBlock_16_Shard-4          300000          4623 ns/op
BenchmarkMultiGetSetBlock_32_Shard-4          300000          4402 ns/op
BenchmarkMultiGetSetBlock_256_Shard-4         300000          4104 ns/op
BenchmarkKeys-4                                  500       3339432 ns/op
ok      _/home/rossmohax/repos/external/concurrent-map  37.088s
```

After

```
BenchmarkItems-4                                 200       8357663 ns/op
BenchmarkMarshalJson-4                            50      26142281 ns/op
BenchmarkStrconv-4                          20000000           127 ns/op
BenchmarkSingleInsertAbsent-4                1000000          1890 ns/op
BenchmarkSingleInsertPresent-4               5000000           257 ns/op
BenchmarkMultiInsertDifferent_1_Shard-4       500000          4666 ns/op
BenchmarkMultiInsertDifferent_16_Shard-4      500000          4447 ns/op
BenchmarkMultiInsertDifferent_32_Shard-4      500000          4881 ns/op
BenchmarkMultiInsertDifferent_256_Shard-4     300000          5393 ns/op
BenchmarkMultiInsertSame-4                    500000          2633 ns/op
BenchmarkMultiGetSame-4                      2000000           991 ns/op
BenchmarkMultiGetSetDifferent_1_Shard-4       300000          5495 ns/op
BenchmarkMultiGetSetDifferent_16_Shard-4      300000          5788 ns/op
BenchmarkMultiGetSetDifferent_32_Shard-4      300000          5528 ns/op
BenchmarkMultiGetSetDifferent_256_Shard-4     300000          5423 ns/op
BenchmarkMultiGetSetBlock_1_Shard-4           300000          4322 ns/op
BenchmarkMultiGetSetBlock_16_Shard-4          300000          4422 ns/op
BenchmarkMultiGetSetBlock_32_Shard-4          500000          4154 ns/op
BenchmarkMultiGetSetBlock_256_Shard-4         500000          4040 ns/op
BenchmarkKeys-4                                  500       3329185 ns/op
ok      _/home/rossmohax/repos/external/concurrent-map  40.550s
```
