### PR TITLE
fix `Keys` function returns `nil` keys when concurrently removing.

### DIFF
--- a/concurrent_map.go
+++ b/concurrent_map.go
@@ -249,9 +249,9 @@ func (m ConcurrentMap) Keys() []string {
 	}()
 
 	// Generate keys
-	keys := make([]string, count)
-	for i := 0; i < count; i++ {
-		keys[i] = <-ch
+	keys := make([]string, 0, count)
+	for k := range ch {
+		keys = append(keys, k)
 	}
 	return keys
 }

--- a/concurrent_map_test.go
+++ b/concurrent_map_test.go
@@ -443,3 +443,27 @@ func TestUpsert(t *testing.T) {
 		t.Error("Upsert, then Upsert failed")
 	}
 }
+
+func TestKeysWhenRemoving(t *testing.T) {
+	m := New()
+
+	// Insert 100 elements.
+	Total := 100
+	for i := 0; i < Total; i++ {
+		m.Set(strconv.Itoa(i), Animal{strconv.Itoa(i)})
+	}
+
+	// Remove 10 elements concurrently.
+	Num := 10
+	for i := 0; i < Num; i++ {
+		go func(c *ConcurrentMap, n int) {
+			c.Remove(strconv.Itoa(n))
+		}(&m, i)
+	}
+	keys := m.Keys()
+	for _, k := range keys {
+		if k == "" {
+			t.Error("Empty keys returned")
+		}
+	}
+}


### PR DESCRIPTION
Now the `Keys` function return a fixed length key slice whose length
is calculated at the beginning of the function. When the `map` removes
element during the function body, the returned result will contain `nil`
keys, in our case, empty strings. This commit fixes this bug by using
`append` function on a zero length slice with the initial length of the
map as `cap`.