### PR TITLE
Fix deadlock when using Iter/IterBuffered

### DIFF
--- a/concurrent_map_test.go
+++ b/concurrent_map_test.go
@@ -467,3 +467,108 @@ func TestKeysWhenRemoving(t *testing.T) {
 		}
 	}
 }
+
+//
+func TestUnDrainedIter(t *testing.T) {
+	m := New()
+	// Insert 100 elements.
+	Total := 100
+	for i := 0; i < Total; i++ {
+		m.Set(strconv.Itoa(i), Animal{strconv.Itoa(i)})
+	}
+	counter := 0
+	// Iterate over elements.
+	ch := m.Iter()
+	for item := range ch {
+		val := item.Val
+
+		if val == nil {
+			t.Error("Expecting an object.")
+		}
+		counter++
+		if counter == 42 {
+			break
+		}
+	}
+	for i := Total; i < 2*Total; i++ {
+		m.Set(strconv.Itoa(i), Animal{strconv.Itoa(i)})
+	}
+	for item := range ch {
+		val := item.Val
+
+		if val == nil {
+			t.Error("Expecting an object.")
+		}
+		counter++
+	}
+
+	if counter != 100 {
+		t.Error("We should have been right where we stopped")
+	}
+
+	counter = 0
+	for item := range m.IterBuffered() {
+		val := item.Val
+
+		if val == nil {
+			t.Error("Expecting an object.")
+		}
+		counter++
+	}
+
+	if counter != 200 {
+		t.Error("We should have counted 200 elements.")
+	}
+}
+
+func TestUnDrainedIterBuffered(t *testing.T) {
+	m := New()
+	// Insert 100 elements.
+	Total := 100
+	for i := 0; i < Total; i++ {
+		m.Set(strconv.Itoa(i), Animal{strconv.Itoa(i)})
+	}
+	counter := 0
+	// Iterate over elements.
+	ch := m.IterBuffered()
+	for item := range ch {
+		val := item.Val
+
+		if val == nil {
+			t.Error("Expecting an object.")
+		}
+		counter++
+		if counter == 42 {
+			break
+		}
+	}
+	for i := Total; i < 2*Total; i++ {
+		m.Set(strconv.Itoa(i), Animal{strconv.Itoa(i)})
+	}
+	for item := range ch {
+		val := item.Val
+
+		if val == nil {
+			t.Error("Expecting an object.")
+		}
+		counter++
+	}
+
+	if counter != 100 {
+		t.Error("We should have been right where we stopped")
+	}
+
+	counter = 0
+	for item := range m.IterBuffered() {
+		val := item.Val
+
+		if val == nil {
+			t.Error("Expecting an object.")
+		}
+		counter++
+	}
+
+	if counter != 200 {
+		t.Error("We should have counted 200 elements.")
+	}
+}


### PR DESCRIPTION
As mentioned by @efeller. When Using the current implementation,
after calling Iter/IterBuffered, if the returned channel were
not drained, some readlock may not be properly released. Which
cause subsequent call to change the map, namely Set/Remove/Pop
operations to block forever, thus a deadlock occurs.

We introduce two test functions (TestUnDrainedIter and
TestUnDrainedIterBuffered) which demonstrate the bug.

This main idea of the fix is to take a snapshot of the current
concurrentMap when calling Iter/IterBuffered. We factor out a
`snapshot` function here, which returns an array of buffered
channels(one per each shard, the readlocks are released after the
related channel is populated). They then fan in to a return channel.
In the buffered case, the size of the returned channel is the sum
of length of all the channels. We avoid using `m.Count()` here since
`m` may change between the function calls, which makes it inaccurate.

This fix passes those two test functions mentioned before.