### PR TITLE
Added RemoveCb to atomically remove elements

### DIFF
--- a/concurrent_map.go
+++ b/concurrent_map.go
@@ -122,6 +122,26 @@ func (m ConcurrentMap) Remove(key string) {
 	shard.Unlock()
 }
 
+// RemoveCb is a callback executed in a map.RemoveCb() call, while Lock is held
+// If returns true, the element will be removed from the map
+type RemoveCb func(key string, v interface{}, exists bool) bool
+
+// RemoveCb locks the shard containing the key, retrieves its current value and calls the callback with those params
+// If callback returns true and element exists, it will remove it from the map
+// Returns the value returned by the callback (even if element was not present in the map)
+func (m ConcurrentMap) RemoveCb(key string, cb RemoveCb) bool {
+	// Try to get shard.
+	shard := m.GetShard(key)
+	shard.Lock()
+	v, ok := shard.items[key]
+	remove := cb(key, v, ok)
+	if remove && ok {
+		delete(shard.items, key)
+	}
+	shard.Unlock()
+	return remove
+}
+
 // Removes an element from the map and returns it
 func (m ConcurrentMap) Pop(key string) (v interface{}, exists bool) {
 	// Try to get shard.

--- a/concurrent_map_test.go
+++ b/concurrent_map_test.go
@@ -124,6 +124,98 @@ func TestRemove(t *testing.T) {
 	m.Remove("noone")
 }
 
+func TestRemoveCb(t *testing.T) {
+	m := New()
+
+	monkey := Animal{"monkey"}
+	m.Set("monkey", monkey)
+	elephant := Animal{"elephant"}
+	m.Set("elephant", elephant)
+
+	var (
+		mapKey string
+		mapVal interface{}
+		wasFound bool
+
+	)
+	cb := func(key string, val interface{}, exists bool) bool {
+		mapKey = key
+		mapVal = val
+		wasFound = exists
+
+		if animal, ok := val.(Animal); ok {
+			return animal.name == "monkey"
+		}
+		return false
+	}
+
+	// Monkey should be removed
+	result := m.RemoveCb("monkey", cb)
+	if !result {
+		t.Errorf("Result was not true")
+	}
+
+	if mapKey != "monkey" {
+		t.Error("Wrong key was provided to the callback")
+	}
+
+	if mapVal != monkey {
+		t.Errorf("Wrong value was provided to the value")
+	}
+
+	if !wasFound {
+		t.Errorf("Key was not found")
+	}
+
+	if m.Has("monkey") {
+		t.Errorf("Key was not removed")
+	}
+
+	// Elephant should not be removed
+	result = m.RemoveCb("elephant", cb)
+	if result {
+		t.Errorf("Result was true")
+	}
+
+	if mapKey != "elephant" {
+		t.Error("Wrong key was provided to the callback")
+	}
+
+	if mapVal != elephant {
+		t.Errorf("Wrong value was provided to the value")
+	}
+
+	if !wasFound {
+		t.Errorf("Key was not found")
+	}
+
+	if !m.Has("elephant") {
+		t.Errorf("Key was removed")
+	}
+
+	// Unset key should remain unset
+	result = m.RemoveCb("horse", cb)
+	if result {
+		t.Errorf("Result was true")
+	}
+
+	if mapKey != "horse" {
+		t.Error("Wrong key was provided to the callback")
+	}
+
+	if mapVal != nil {
+		t.Errorf("Wrong value was provided to the value")
+	}
+
+	if wasFound {
+		t.Errorf("Key was found")
+	}
+
+	if m.Has("horse") {
+		t.Errorf("Key was created")
+	}
+}
+
 func TestPop(t *testing.T) {
 	m := New()
 


### PR DESCRIPTION
RemoveCb removes elements if callback returns true, depending on the value of the element and deciding while lock is held.

It's a solution proposal for https://github.com/orcaman/concurrent-map/issues/61

I've included the key in the callback thinking about a possible future implementation of some kind of `RemoveIterCb`, useful for cleaning up the map.