### PR TITLE
Add support for a custom number of shards for the map

### DIFF
--- a/concurrent_map_bench_test.go
+++ b/concurrent_map_bench_test.go
@@ -177,10 +177,10 @@ func GetSet(m ConcurrentMap, finished chan struct{}) (set func(key, value string
 }
 
 func runWithShards(bench func(b *testing.B), b *testing.B, shardsCount int) {
-	oldShardsCount := SHARD_COUNT
-	SHARD_COUNT = shardsCount
+	oldShardsCount := DEFAULT_SHARD_COUNT
+	DEFAULT_SHARD_COUNT = shardsCount
 	bench(b)
-	SHARD_COUNT = oldShardsCount
+	DEFAULT_SHARD_COUNT = oldShardsCount
 }
 
 func BenchmarkKeys(b *testing.B) {

--- a/concurrent_map_test.go
+++ b/concurrent_map_test.go
@@ -14,7 +14,7 @@ type Animal struct {
 
 func TestMapCreation(t *testing.T) {
 	m := New()
-	if m == nil {
+	if m.maps == nil {
 		t.Error("map is null.")
 	}
 
@@ -426,9 +426,9 @@ func TestConcurrent(t *testing.T) {
 }
 
 func TestJsonMarshal(t *testing.T) {
-	SHARD_COUNT = 2
+	DEFAULT_SHARD_COUNT = 2
 	defer func() {
-		SHARD_COUNT = 32
+		DEFAULT_SHARD_COUNT = 32
 	}()
 	expected := "{\"a\":1,\"b\":2}"
 	m := New()


### PR DESCRIPTION
This adds a new constructor to the ConcurrentMap that allows the user to pass in the number of shards we should shard the map to