### PR TITLE
update golang repo issue link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 As explained [here](http://golang.org/doc/faq#atomic_maps) and [here](http://blog.golang.org/go-maps-in-action), the `map` type in Go doesn't support concurrent reads and writes. `concurrent-map` provides a high-performance solution to this by sharding the map with minimal time spent waiting for locks.
 
-Prior to Go 1.9, there was no concurrent map implementation in the stdlib. In Go 1.9, `sync.Map` was introduced. The new `sync.Map` has a few key differences from this map. The stdlib `sync.Map` is designed for append-only scenarios. So if you want to use the map for something more like in-memory db, you might benefit from using our version. You can read more about it in the golang repo, for example [here](golang/go#21035) and [here](https://stackoverflow.com/questions/11063473/map-with-concurrent-access)
+Prior to Go 1.9, there was no concurrent map implementation in the stdlib. In Go 1.9, `sync.Map` was introduced. The new `sync.Map` has a few key differences from this map. The stdlib `sync.Map` is designed for append-only scenarios. So if you want to use the map for something more like in-memory db, you might benefit from using our version. You can read more about it in the golang repo, for example [here](https://github.com/golang/go/issues/21035) and [here](https://stackoverflow.com/questions/11063473/map-with-concurrent-access)
 
 ## usage
 


### PR DESCRIPTION
The `golang/go#21035` reference is no longer valid in GitHub's readme rendering.

By now, clicking from the README, the browser will be redirected to `https://github.com/orcaman/concurrent-map/blob/master/golang/go#21035`.