### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/concurrent_map.go
+++ b/concurrent_map.go
@@ -26,7 +26,7 @@ func New() ConcurrentMap {
 	return m
 }
 
-// Returns shard under given key
+// GetShard returns shard under given key
 func (m ConcurrentMap) GetShard(key string) *ConcurrentMapShared {
 	return m[uint(fnv32(key))%uint(SHARD_COUNT)]
 }
@@ -79,7 +79,7 @@ func (m ConcurrentMap) SetIfAbsent(key string, value interface{}) bool {
 	return !ok
 }
 
-// Retrieves an element from map under given key.
+// Get retrieves an element from map under given key.
 func (m ConcurrentMap) Get(key string) (interface{}, bool) {
 	// Get shard
 	shard := m.GetShard(key)
@@ -90,7 +90,7 @@ func (m ConcurrentMap) Get(key string) (interface{}, bool) {
 	return val, ok
 }
 
-// Returns the number of elements within the map.
+// Count returns the number of elements within the map.
 func (m ConcurrentMap) Count() int {
 	count := 0
 	for i := 0; i < SHARD_COUNT; i++ {
@@ -113,7 +113,7 @@ func (m ConcurrentMap) Has(key string) bool {
 	return ok
 }
 
-// Removes an element from the map.
+// Remove removes an element from the map.
 func (m ConcurrentMap) Remove(key string) {
 	// Try to get shard.
 	shard := m.GetShard(key)
@@ -142,7 +142,7 @@ func (m ConcurrentMap) RemoveCb(key string, cb RemoveCb) bool {
 	return remove
 }
 
-// Removes an element from the map and returns it
+// Pop removes an element from the map and returns it
 func (m ConcurrentMap) Pop(key string) (v interface{}, exists bool) {
 	// Try to get shard.
 	shard := m.GetShard(key)
@@ -153,7 +153,7 @@ func (m ConcurrentMap) Pop(key string) (v interface{}, exists bool) {
 	return v, exists
 }
 
-// Checks if map is empty.
+// IsEmpty checks if map is empty.
 func (m ConcurrentMap) IsEmpty() bool {
 	return m.Count() == 0
 }
@@ -164,7 +164,7 @@ type Tuple struct {
 	Val interface{}
 }
 
-// Returns an iterator which could be used in a for range loop.
+// Iter returns an iterator which could be used in a for range loop.
 //
 // Deprecated: using IterBuffered() will get a better performence
 func (m ConcurrentMap) Iter() <-chan Tuple {
@@ -174,7 +174,7 @@ func (m ConcurrentMap) Iter() <-chan Tuple {
 	return ch
 }
 
-// Returns a buffered iterator which could be used in a for range loop.
+// IterBuffered returns a buffered iterator which could be used in a for range loop.
 func (m ConcurrentMap) IterBuffered() <-chan Tuple {
 	chans := snapshot(m)
 	total := 0
@@ -228,7 +228,7 @@ func fanIn(chans []chan Tuple, out chan Tuple) {
 	close(out)
 }
 
-// Returns all items as map[string]interface{}
+// Items returns all items as map[string]interface{}
 func (m ConcurrentMap) Items() map[string]interface{} {
 	tmp := make(map[string]interface{})
 
@@ -259,7 +259,7 @@ func (m ConcurrentMap) IterCb(fn IterCb) {
 	}
 }
 
-// Return all keys as []string
+// Keys returns all keys as []string
 func (m ConcurrentMap) Keys() []string {
 	count := m.Count()
 	ch := make(chan string, count)


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from Effective Go. It’s admittedly a relatively minor fix up. Does this help you?