### PR TITLE
Feat/en 1525 optimized concurrent map cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,19 @@
-go.mod
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+.*
+!/.gitignore
+
+/vendor
+.env
+*.log

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/ElrondNetwork/concurrent-map
+
+go 1.12


### PR DESCRIPTION
Extended the concurrent map cache with eviction scheme.
The insert/remove of key elements into and from the key list is adapted to the sharding scheme of the main implementation.