### PR TITLE
panic when accessing map elements before initializing

### DIFF
--- a/concurrent_map.go
+++ b/concurrent_map.go
@@ -198,6 +198,10 @@ func (m ConcurrentMap) Clear() {
 // It returns once the size of each buffered channel is determined,
 // before all the channels are populated using goroutines.
 func snapshot(m ConcurrentMap) (chans []chan Tuple) {
+	//When you access map items before initializing.
+	if len(m) == 0{
+		panic(`cmap.ConcurrentMap is not initialized. Should run New() before usage.`)
+	}
 	chans = make([]chan Tuple, SHARD_COUNT)
 	wg := sync.WaitGroup{}
 	wg.Add(SHARD_COUNT)


### PR DESCRIPTION
Panic when the map hasn't been initialized. Running items without initializing blocks indefinitely. 
```
        var myMap cmap.ConcurrentMap
	for k, _ := range myMap.Items() {
           //code here
	}
        //Never reached, should run cmap.New() first.
```