### PR TITLE
update url to latest V2 version in README file

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -11,13 +11,13 @@
 
 ```go
 import (
-	"github.com/orcaman/concurrent-map"
+	"github.com/orcaman/concurrent-map/v2"
 )
 
 ```
 
 ```bash
-go get "github.com/orcaman/concurrent-map"
+go get "github.com/orcaman/concurrent-map/v2"
 ```
 
 现在包被导入到了`cmap`命名空间下
@@ -46,7 +46,7 @@ go get "github.com/orcaman/concurrent-map"
 运行测试:
 
 ```bash
-go test "github.com/orcaman/concurrent-map"
+go test "github.com/orcaman/concurrent-map/v2"
 ```
 
 ## 贡献说明

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Import the package:
 
 ```go
 import (
-	"github.com/orcaman/concurrent-map"
+	"github.com/orcaman/concurrent-map/v2"
 )
 
 ```
 
 ```bash
-go get "github.com/orcaman/concurrent-map"
+go get "github.com/orcaman/concurrent-map/v2"
 ```
 
 The package is now imported under the "cmap" namespace.
@@ -44,7 +44,7 @@ For more examples have a look at concurrent_map_test.go.
 Running tests:
 
 ```bash
-go test "github.com/orcaman/concurrent-map"
+go test "github.com/orcaman/concurrent-map/v2"
 ```
 
 ## guidelines for contributing


### PR DESCRIPTION
This is a minor problem, but it will confuse the new visitor like me :)

Since `cmap` update to v2 version and introduce `generics`, the `README.md` and `README-zh.md` should update too. Otherwise `go mod XXX` or `go get XXX` will use the latest `V1` version of `cmap`