### PR TITLE
Remind count of map and add benchmark

### DIFF
--- a/concurrent_map_bench_test.go
+++ b/concurrent_map_bench_test.go
@@ -292,7 +292,6 @@ func BenchmarkMultiGetSetBlock_256_Shard(b *testing.B) {
 	runWithShards(benchmarkMultiGetSetBlock, b, 256)
 }
 
-
 func GetSet[K comparable, V any](m ConcurrentMap[K, V], finished chan struct{}) (set func(key K, value V), get func(key K, value V)) {
 	return func(key K, value V) {
 			for i := 0; i < 10; i++ {
@@ -339,5 +338,41 @@ func BenchmarkKeys(b *testing.B) {
 	}
 	for i := 0; i < b.N; i++ {
 		m.Keys()
+	}
+}
+
+func BenchmarkCount(b *testing.B) {
+	m := New[Animal]()
+
+	// Insert 100 elements.
+	for i := 0; i < 10000; i++ {
+		m.Set(strconv.Itoa(i), Animal{strconv.Itoa(i)})
+	}
+	for i := 0; i < b.N; i++ {
+		m.Count()
+	}
+}
+
+func BenchmarkRemoveExists(b *testing.B) {
+	m := New[Animal]()
+
+	// Insert 100 elements.
+	for i := 0; i < 10000; i++ {
+		m.Set(strconv.Itoa(i), Animal{strconv.Itoa(i)})
+	}
+	for i := 0; i < b.N; i++ {
+		m.Remove(strconv.Itoa(i))
+	}
+}
+
+func BenchmarkRemoveNotExists(b *testing.B) {
+	m := New[Animal]()
+
+	// Insert 100 elements.
+	for i := 0; i < 10000; i++ {
+		m.Set(strconv.Itoa(i), Animal{strconv.Itoa(i)})
+	}
+	for i := 0; i < b.N; i++ {
+		m.Remove(strconv.Itoa(0))
 	}
 }


### PR DESCRIPTION
the old:
BenchmarkCount
BenchmarkCount-8   	 2150287	       514.2 ns/op
the new:
BenchmarkCount
BenchmarkCount-8   	393898780	         2.755 ns/op

And otherwise ,the insert from 
the new
BenchmarkItems-8                            	     278	   4242234 ns/op
the old
BenchmarkItems-8                            	     258	   4090206 ns/op

Fixes: https://github.com/orcaman/concurrent-map/issues/143
